### PR TITLE
Add support for filtering pods by namespace

### DIFF
--- a/main.go
+++ b/main.go
@@ -137,10 +137,12 @@ Options:`)
 	var resp metav1.Table
 	switch queryStrategy {
 	case queryAllPods:
-		resp, err = findPodsByQueryingAllPods(ctx, podsRestClient, matchedNodes, *useWatchCache)
+		resp, err = findPodsByQueryingAllPods(ctx, podsRestClient, matchedNodes,
+			*useWatchCache, *kubeConfigFlags.Namespace)
 	case queryPodPerNodeInParallel:
 		klog.V(1).Infof("querying list of pods on each node in parallel (workers: %d)", *numWorkers)
-		resp, err = findPodsByQueryingNodesInParallel(ctx, podsRestClient, matchedNodes.UnsortedList(), *numWorkers, *useWatchCache)
+		resp, err = findPodsByQueryingNodesInParallel(ctx, podsRestClient, matchedNodes.UnsortedList(),
+			*numWorkers, *useWatchCache, *kubeConfigFlags.Namespace)
 	default:
 		klog.Fatalf("unknown pod query strategy: %q", queryStrategy)
 	}


### PR DESCRIPTION
Currently if you pass in the `-n` or `--namespace` CLI flag it is ignored. 

This change passes the kubectl namespace flag to the rest client so pods are properly filtered if selecting a namespace.